### PR TITLE
Add autoload

### DIFF
--- a/essgd.el
+++ b/essgd.el
@@ -137,6 +137,7 @@ This allows us to respond automatically to new plots."
 ;; https://cran.r-project.org/web/packages/httpgd/vignettes/c01_httpgd-api.html
 ;; curl -s http://127.0.0.1:5900/plot?index=2&width=800&height=600 > /tmp/a.svg
 
+;;;###autoload
 (defun essgd-start ()
   "Start an *essgd* buffer to plot R output.
 Must be called from a buffer that is either an *R* process, or attached to one.


### PR DESCRIPTION
Hi,

Thanks so much, fantastic package. I have been waiting for this feature in emacs for so long.

One thing missing in your package: an autoload. Without it, if you defer package loading (using :defer t in use-package), you cannot start essgd.